### PR TITLE
fixed URL() to preserve '/' in original

### DIFF
--- a/name/url.go
+++ b/name/url.go
@@ -1,5 +1,5 @@
 package name
 
 func (n Ident) URL() Ident {
-	return Ident{n.Pluralize().Underscore()}
+	return Ident{n.File().Pluralize()}
 }

--- a/name/url_test.go
+++ b/name/url_test.go
@@ -14,13 +14,16 @@ func Test_URL(t *testing.T) {
 		{"User", "users"},
 		{"widget", "widgets"},
 		{"AdminUser", "admin_users"},
+		{"Admin/User", "admin/users"},
+		{"Admin/Users", "admin/users"},
+		{"/Admin/Users", "/admin/users"},
 	}
 
 	for _, tt := range table {
 		t.Run(tt.in, func(st *testing.T) {
 			r := require.New(st)
 			n := New(tt.in)
-			r.Equal(tt.out, n.URL().String())
+			r.Equal(tt.out, n.URL().String(), "URL of %v", tt.in)
 		})
 	}
 }


### PR DESCRIPTION
To generate URL from paths. (which is include '/')

Previously, it returns `admin_users` for  `admin/user` but it should be `admin/users`.