### PR TITLE
Fix "build" plural

### DIFF
--- a/flect_test.go
+++ b/flect_test.go
@@ -176,6 +176,7 @@ var singlePluralAssertions = []tt{
 	{"plus", "pluses"},
 	{"fuse", "fuses"},
 	{"prometheus", "prometheuses"},
+	{"build", "builds"},
 }
 
 var pluralSingularAssertions = []tt{}

--- a/plural_rules.go
+++ b/plural_rules.go
@@ -36,6 +36,7 @@ var singleToPlural = map[string]string{
 	"basis":       "bases",
 	"beau":        "beaus",
 	"bison":       "bison",
+	"build":       "builds",
 	"bureau":      "bureaus",
 	"bus":         "buses",
 	"campus":      "campuses",


### PR DESCRIPTION
Without this fix plural of "build" was "buildren" as test reveal if "build" is added to tests without fixing source code :

```
make test
"go" test -cover -tags "" ./...
--- FAIL: Test_Pluralize (0.01s)
    --- FAIL: Test_Pluralize/build (0.00s)
        pluralize_test.go:13: 
                Error Trace:    pluralize_test.go:13
                Error:          Not equal: 
                                expected: "builds"
                                actual  : "buildren"
                            
                                Diff:
                                --- Expected
                                +++ Actual
                                @@ -1 +1 @@
                                -builds
                                +buildren
                Test:           Test_Pluralize/build
FAIL
```