### PR TITLE
Capitalize complete acronym if it is first segment

### DIFF
--- a/camelize_test.go
+++ b/camelize_test.go
@@ -28,6 +28,8 @@ func Test_Camelize(t *testing.T) {
 		{"statuses", "statuses"},
 		{"People", "people"},
 		{"people", "people"},
+		{"ip_address", "ipAddress"},
+		{"some_url", "someURL"},
 	}
 
 	for _, tt := range table {

--- a/pascalize.go
+++ b/pascalize.go
@@ -1,7 +1,7 @@
 package flect
 
 import (
-	"unicode"
+	"strings"
 )
 
 // Pascalize returns a string with each segment capitalized
@@ -21,5 +21,12 @@ func (i Ident) Pascalize() Ident {
 	if len(c.String()) == 0 {
 		return c
 	}
-	return New(string(unicode.ToUpper(rune(c.Original[0]))) + c.Original[1:])
+	if len(i.Parts) == 0 {
+		return i
+	}
+	capLen := 1
+	if _, ok := baseAcronyms[strings.ToUpper(i.Parts[0])]; ok {
+		capLen = len(i.Parts[0])
+	}
+	return New(string(strings.ToUpper(c.Original[0:capLen])) + c.Original[capLen:])
 }

--- a/pascalize_test.go
+++ b/pascalize_test.go
@@ -18,6 +18,8 @@ func Test_Pascalize(t *testing.T) {
 		{"i've read a book! have you?", "IveReadABookHaveYou"},
 		{"This is `code` ok", "ThisIsCodeOK"},
 		{"id", "ID"},
+		{"ip_address", "IPAddress"},
+		{"some_url", "SomeURL"},
 	}
 
 	for _, tt := range table {


### PR DESCRIPTION
in pascalized ident

Fixes #39