### PR TITLE
Fix capitalization for non-English strings

### DIFF
--- a/capitalize.go
+++ b/capitalize.go
@@ -15,13 +15,10 @@ func Capitalize(s string) string {
 //	bob dylan = Bob dylan
 //	widget_id = Widget_id
 func (i Ident) Capitalize() Ident {
-	var x string
 	if len(i.Parts) == 0 {
 		return New("")
 	}
-	x = string(unicode.ToTitle(rune(i.Original[0])))
-	if len(i.Original) > 1 {
-		x += i.Original[1:]
-	}
-	return New(x)
+	runes := []rune(i.Original)
+	runes[0] = unicode.ToTitle(runes[0])
+	return New(string(runes))
 }

--- a/capitalize_test.go
+++ b/capitalize_test.go
@@ -15,6 +15,7 @@ func Test_Capitalize(t *testing.T) {
 		{"widget_id", "Widget_id"},
 		{"widget_ID", "Widget_ID"},
 		{"widget ID", "Widget ID"},
+		{"гофер", "Гофер"}, // it's "gopher" in Ukrainian
 	}
 
 	for _, tt := range table {


### PR DESCRIPTION
The current `Capitalize` implementation is broken for non-English strings. I didn't dive deep into analysis of the problem, but the problem seems to appear in the concatenation of `i.Original[1:]` to the capitalized letter. It works only under assumtion that rune of the first character takes exactly 1 byte, which is not true for non-English UTF-8 encoded strings.

My version assumes that capitalized letter should be of the same size as non-capitalized, and just replaces it. I'm not quite sure it's always the case, but should be for most common usages if the first character is a Letter.