### PR TITLE
Add pluralization: synapse -> synapses

### DIFF
--- a/plural_rules.go
+++ b/plural_rules.go
@@ -122,6 +122,7 @@ var singleToPlural = map[string]string{
 	"swine":       "swine",
 	"syllabus":    "syllabi",
 	"symposium":   "symposiums",
+	"synapse":     "synapses",
 	"synopsis":    "synopses",
 	"tableau":     "tableaus",
 	"testis":      "testes",


### PR DESCRIPTION
Without this, it gets pluralized as "synapsis".