### PR TITLE
Capitalize complete acronym if it is first segment - improved

### DIFF
--- a/camelize.go
+++ b/camelize.go
@@ -22,10 +22,6 @@ func (i Ident) Camelize() Ident {
 	for i, part := range i.Parts {
 		var x string
 		var capped bool
-		if strings.ToLower(part) == "id" {
-			out = append(out, "ID")
-			continue
-		}
 		for _, c := range part {
 			if unicode.IsLetter(c) || unicode.IsDigit(c) {
 				if i == 0 {

--- a/camelize_test.go
+++ b/camelize_test.go
@@ -28,6 +28,8 @@ func Test_Camelize(t *testing.T) {
 		{"statuses", "statuses"},
 		{"People", "people"},
 		{"people", "people"},
+		{"ip_address", "ipAddress"},
+		{"some_url", "someURL"},
 	}
 
 	for _, tt := range table {

--- a/camelize_test.go
+++ b/camelize_test.go
@@ -10,6 +10,8 @@ func Test_Camelize(t *testing.T) {
 	table := []tt{
 		{"", ""},
 		{"bob dylan", "bobDylan"},
+		{"id", "id"},
+		{"ID", "id"},
 		{"widgetID", "widgetID"},
 		{"widget_ID", "widgetID"},
 		{"Widget_ID", "widgetID"},

--- a/pascalize.go
+++ b/pascalize.go
@@ -1,7 +1,7 @@
 package flect
 
 import (
-	"unicode"
+	"strings"
 )
 
 // Pascalize returns a string with each segment capitalized
@@ -21,5 +21,12 @@ func (i Ident) Pascalize() Ident {
 	if len(c.String()) == 0 {
 		return c
 	}
-	return New(string(unicode.ToUpper(rune(c.Original[0]))) + c.Original[1:])
+	if len(i.Parts) == 0 {
+		return i
+	}
+	capLen := 1
+	if _, ok := baseAcronyms[strings.ToUpper(i.Parts[0])]; ok {
+		capLen = len(i.Parts[0])
+	}
+	return New(string(strings.ToUpper(c.Original[0:capLen])) + c.Original[capLen:])
 }

--- a/pascalize_test.go
+++ b/pascalize_test.go
@@ -18,6 +18,8 @@ func Test_Pascalize(t *testing.T) {
 		{"i've read a book! have you?", "IveReadABookHaveYou"},
 		{"This is `code` ok", "ThisIsCodeOK"},
 		{"id", "ID"},
+		{"ip_address", "IPAddress"},
+		{"some_url", "SomeURL"},
 	}
 
 	for _, tt := range table {

--- a/pascalize_test.go
+++ b/pascalize_test.go
@@ -10,6 +10,8 @@ func Test_Pascalize(t *testing.T) {
 	table := []tt{
 		{"", ""},
 		{"bob dylan", "BobDylan"},
+		{"ID", "ID"},
+		{"id", "ID"},
 		{"widgetID", "WidgetID"},
 		{"widget_ID", "WidgetID"},
 		{"Widget_ID", "WidgetID"},


### PR DESCRIPTION
- Capitalize complete acronym if it is first segment
- Remove special case for ID to fix ID by itself

Branched off of and supercedes #41; thanks @breml!
