### PR TITLE
Remove `oot/eet` from suffix rules

### DIFF
--- a/flect_test.go
+++ b/flect_test.go
@@ -98,6 +98,7 @@ var singlePluralAssertions = []tt{
 	{"field", "fields"},
 	{"fish", "fish"},
 	{"fix", "fixes"},
+	{"fleet", "fleets"},
 	{"focus", "foci"},
 	{"foobar", "foobars"},
 	{"foot", "feet"},

--- a/plural_rules.go
+++ b/plural_rules.go
@@ -224,7 +224,6 @@ var singularToPluralSuffixList = []singularToPluralSuffix{
 	{"oci", "ocus"},
 	{"ode", "odes"},
 	{"ofe", "oves"},
-	{"oot", "eet"},
 	{"pfe", "pves"},
 	{"pse", "psis"},
 	{"qfe", "qves"},


### PR DESCRIPTION
**Issue:** https://github.com/gobuffalo/flect/issues/53

**Description:** Removing `{"oot", "eet"},` entry from suffix rules because it is causing issues for words like `fleet`, and I don't think it's popular enough to warrant its own rule/suffix (*note: I'm not an english major*). For the few exceptions, we can add to `singleToPlural` collection like with tooth/teeth & foot/feet

**Validation:** `make test`