### PR TITLE
fixed #24 by adjusting the function's conditions

### DIFF
--- a/name/folder.go
+++ b/name/folder.go
@@ -3,34 +3,39 @@ package name
 import (
 	"regexp"
 	"strings"
+
+	"github.com/gobuffalo/flect"
 )
 
-var alphanum = regexp.MustCompile(`[^a-zA-Z0-9_\-\/]+`)
+var alphanum = regexp.MustCompile(`[^a-zA-Z0-9_]+`)
 
-// Folder creates a suitable folder name
-//	admin/widget = admin/widget
-//	foo_bar = foo_bar
-//	U$ser = u_ser
+// Folder returns a suitable folder name. It removes any special characters
+// from the given string `s` and returns a string consists of alpha-numeric
+// characters.
+//	admin/widget --> admin/widget
+//	adminUser --> admin_user
+//	foo_bar --> foo_bar
+//	Admin --> admin
+//	U$ser --> u_ser
 func Folder(s string, exts ...string) string {
 	return New(s).Folder(exts...).String()
 }
 
-// Folder creates a suitable folder name
-//	admin/widget = admin/widget
-//	foo_bar = foo/bar
-//	U$ser = u/ser
+// Folder returns a suitable folder name. It removes any special characters
+// from the given string `s` and returns a string consists of alpha-numeric
+// characters.
+//	admin/widget --> admin/widget
+//	adminUser --> admin_user
+//	foo_bar --> foo_bar
+//	Admin --> admin
+//	U$ser --> u_ser
 func (i Ident) Folder(exts ...string) Ident {
 	var parts []string
 
-	s := i.Original
-	if i.Pascalize().String() == s {
-		s = i.Underscore().String()
-		s = strings.Replace(s, "_", "/", -1)
-	}
-	for _, part := range strings.Split(s, "/") {
-		part = strings.ToLower(part)
-		part = alphanum.ReplaceAllString(part, "")
+	for _, part := range strings.Split(i.Original, "/") {
+		part = alphanum.ReplaceAllString(flect.Underscore(part), "")
 		parts = append(parts, part)
 	}
+
 	return New(strings.Join(parts, "/") + strings.Join(exts, ""))
 }

--- a/name/folder_test.go
+++ b/name/folder_test.go
@@ -9,14 +9,18 @@ import (
 func Test_Folder(t *testing.T) {
 	table := []tt{
 		{"", ""},
-		{"foo_bar", "foo_bar"},
 		{"admin/widget", "admin/widget"},
 		{"admin/widgets", "admin/widgets"},
 		{"widget", "widget"},
 		{"widgets", "widgets"},
 		{"User", "user"},
-		{"U$er", "uer"},
-		{"AdminUser", "admin/user"},
+		{"U$er", "u_er"},
+		{"adminuser", "adminuser"},
+		{"Adminuser", "adminuser"},
+		{"AdminUser", "admin_user"},
+		{"adminUser", "admin_user"},
+		{"admin-user", "admin_user"},
+		{"admin_user", "admin_user"},
 	}
 
 	for _, tt := range table {

--- a/underscore.go
+++ b/underscore.go
@@ -6,17 +6,17 @@ import (
 )
 
 // Underscore a string
-//	bob dylan = bob_dylan
-//	Nice to see you! = nice_to_see_you
-//	widgetID = widget_id
+//	bob dylan --> bob_dylan
+//	Nice to see you! --> nice_to_see_you
+//	widgetID --> widget_id
 func Underscore(s string) string {
 	return New(s).Underscore().String()
 }
 
 // Underscore a string
-//	bob dylan = bob_dylan
-//	Nice to see you! = nice_to_see_you
-//	widgetID = widget_id
+//	bob dylan --> bob_dylan
+//	Nice to see you! --> nice_to_see_you
+//	widgetID --> widget_id
 func (i Ident) Underscore() Ident {
 	out := make([]string, 0, len(i.Parts))
 	for _, part := range i.Parts {


### PR DESCRIPTION
The function logic has inconsistent condition logic even though the purpose of the function should be to remove special characters from the given string to make it suitable as a general folder name.

Simplified the condition and processing flow and the issue was fixed. now, the transformation is simple, all of the following will be `admin_user`:

* `AdminUser`
* `adminUser`
* `admin-user`
* `admin_user`
* `admin^user`

This is a breaking change to the users who used the pascal case names as the argument of the function since those were transformed into a sub-folder form previously.

fixes #24 and maybe https://github.com/gobuffalo/buffalo/issues/1769 too.