### PR TITLE
removed deprecated strings.Title(), updated test cases and benchmarks

### DIFF
--- a/humanize.go
+++ b/humanize.go
@@ -22,13 +22,9 @@ func (i Ident) Humanize() Ident {
 		return New("")
 	}
 
-	var parts []string
-	for index, part := range i.Parts {
-		if index == 0 {
-			part = strings.Title(i.Parts[0])
-		}
-
-		parts = xappend(parts, part)
+	parts := xappend([]string{}, Titleize(i.Parts[0]))
+	if len(i.Parts) > 1 {
+		parts = xappend(parts, i.Parts[1:]...)
 	}
 
 	return New(strings.Join(parts, " "))

--- a/humanize_test.go
+++ b/humanize_test.go
@@ -9,7 +9,10 @@ import (
 func Test_Humanize(t *testing.T) {
 	table := []tt{
 		{"", ""},
+		{"id", "ID"},
+		{"url", "URL"},
 		{"IBM", "IBM"},
+		{"CAUTION! CAPs are CAPs!", "CAUTION! CAPs are CAPs!"},
 		{"employee_mobile_number", "Employee mobile number"},
 		{"employee_salary", "Employee salary"},
 		{"employee_id", "Employee ID"},

--- a/pluralize_test.go
+++ b/pluralize_test.go
@@ -39,3 +39,14 @@ func Test_PluralizeWithSize(t *testing.T) {
 		})
 	}
 }
+
+func BenchmarkPluralize(b *testing.B) {
+	for n := 0; n < b.N; n++ {
+		for _, tt := range singlePluralAssertions {
+			if tt.doPluralizeTest {
+				Pluralize(tt.singular)
+				Pluralize(tt.plural)
+			}
+		}
+	}
+}

--- a/singularize_test.go
+++ b/singularize_test.go
@@ -39,3 +39,14 @@ func Test_SingularizeWithSize(t *testing.T) {
 		})
 	}
 }
+
+func BenchmarkSingularize(b *testing.B) {
+	for n := 0; n < b.N; n++ {
+		for _, tt := range singlePluralAssertions {
+			if tt.doSingularizeTest {
+				Singularize(tt.singular)
+				Singularize(tt.plural)
+			}
+		}
+	}
+}

--- a/version.go
+++ b/version.go
@@ -1,4 +1,4 @@
 package flect
 
 //Version holds Flect version number
-const Version = "v0.1.6"
+const Version = "v1.0.0"


### PR DESCRIPTION
### What is being done in this PR?
* Removed deprecated method `strings.Title()` by utilizing `Titlelize()`
* Updated test cases for `Humanize()`
* Added benchmark tests for `Pluralize()` and `Singularize()`
* version bump