### PR TITLE
fixed incorrect titleizing of unicode string

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,3 +5,5 @@ go 1.16
 exclude github.com/stretchr/testify v1.7.1
 
 require github.com/stretchr/testify v1.8.1
+
+retract [v1.0.0, v1.0.1]

--- a/humanize_test.go
+++ b/humanize_test.go
@@ -20,6 +20,7 @@ func Test_Humanize(t *testing.T) {
 		{"first_name", "First name"},
 		{"first_Name", "First Name"},
 		{"firstName", "First Name"},
+		{"óbito", "Óbito"},
 	}
 
 	for _, tt := range table {

--- a/titleize.go
+++ b/titleize.go
@@ -19,12 +19,20 @@ func Titleize(s string) string {
 //	"This is `code` ok" = "This Is `code` OK"
 func (i Ident) Titleize() Ident {
 	var parts []string
+
+	// TODO: we need to reconsider the design.
+	//       this approach preserves inline code block as is but it also
+	//       preserves the other words start with a special character.
+	//       I would prefer: "*wonderful* world" to be "*Wonderful* World"
 	for _, part := range i.Parts {
-		x := string(unicode.ToTitle(rune(part[0])))
-		if len(part) > 1 {
-			x += part[1:]
+		// CAUTION: in unicode, []rune(str)[0] is not rune(str[0])
+		runes := []rune(part)
+		x := string(unicode.ToTitle(runes[0]))
+		if len(runes) > 1 {
+			x += string(runes[1:])
 		}
 		parts = append(parts, x)
 	}
+
 	return New(strings.Join(parts, " "))
 }

--- a/titleize_test.go
+++ b/titleize_test.go
@@ -12,11 +12,13 @@ func Test_Titleize(t *testing.T) {
 		{"bob dylan", "Bob Dylan"},
 		{"Nice to see you!", "Nice To See You!"},
 		{"*hello*", "*hello*"},
+		{"hello *wonderful* world!", "Hello *wonderful* World!"}, // CHKME
 		{"i've read a book! have you?", "I've Read A Book! Have You?"},
 		{"This is `code` ok", "This Is `code` OK"},
 		{"foo_bar", "Foo Bar"},
 		{"admin/widget", "Admin Widget"},
 		{"widget", "Widget"},
+		{"óbito", "Óbito"},
 	}
 
 	for _, tt := range table {


### PR DESCRIPTION
### What is being done in this PR?

- fixed incorrect `Titleize()` of Unicode string
- it fixes incorrect `Humanize()` which is now depends on `Titleize()`

fixes #67

### What are the main choices made to get to this solution?

The previous code uses `rune(part[0])` to pick the first character of the string but this is incorrect usage of the rune type. It should be `[]rune(part)[0]`. We can also consider using `golang.org/x/text` module to handle this issue better in the future.

### What was discovered while working on it? (Optional)

`Titleize()` ignores a part that starts with a special character such as `` ` ``, `*` so the result will be:

* "using `rune` correctly" --> "Using `rune` Correctly" (which is fine)
* "what a *wonderful* world" --> "What A *wonderful* World" (which is odd to me)

We need to reconsider the design.