### PR TITLE
fix incorrect pluralization of words ending with da

### DIFF
--- a/flect_test.go
+++ b/flect_test.go
@@ -227,6 +227,10 @@ var singlePluralAssertions = []dict{
 	{"media", "media", true, true}, // instead of mediae, popular case
 	{"multimedia", "multimedia", true, true},
 
+	// Words that end in -da change -da to -das
+	{"andromeda", "andromedas", true, true},
+	{"veranda", "verandas", true, true},
+
 	// Words that end in -ch, -o, -s, -sh, -x, -z
 	{"lunch", "lunches", true, true},
 	{"search", "searches", true, true},

--- a/plural_rules.go
+++ b/plural_rules.go
@@ -294,6 +294,9 @@ var singularToPluralSuffixList = []singularToPluralSuffix{
 	{"nula", "bulae"},
 	{"vula", "bulae"},
 
+	// Words ending with -da change -da to -das
+	{"da", "das"},
+
 	// Words from Greek that end in -on change -on to -a (eg, polyhedron becomes polyhedra)
 	// https://en.wiktionary.org/wiki/Category:English_irregular_plurals_ending_in_"-a"
 	{"hedron", "hedra"},


### PR DESCRIPTION
### What is being done in this PR?
* fix incorrect pluralization of words ending with da - https://github.com/gobuffalo/flect/issues/72

### What are the main choices made to get to this solution?
I couldn't find words ending with -da that doesn't conform to this rule

### What was discovered while working on it? (Optional)

### List the manual test cases you've covered before sending this PR:
andromeda, veranda