### PR TITLE
fix for panics when humanize called on whitespace

### DIFF
--- a/humanize.go
+++ b/humanize.go
@@ -7,6 +7,7 @@ import (
 // Humanize returns first letter of sentence capitalized.
 // Common acronyms are capitalized as well.
 // Other capital letters in string are left as provided.
+//
 //	employee_salary = Employee salary
 //	employee_id = employee ID
 //	employee_mobile_number = Employee mobile number
@@ -20,6 +21,10 @@ func Humanize(s string) string {
 func (i Ident) Humanize() Ident {
 	if len(i.Original) == 0 {
 		return New("")
+	}
+
+	if strings.TrimSpace(i.Original) == "" {
+		return i
 	}
 
 	parts := xappend([]string{}, Titleize(i.Parts[0]))

--- a/humanize_test.go
+++ b/humanize_test.go
@@ -21,6 +21,11 @@ func Test_Humanize(t *testing.T) {
 		{"first_Name", "First Name"},
 		{"firstName", "First Name"},
 		{"óbito", "Óbito"},
+		{" ", " "},
+		{"\n", "\n"},
+		{"\r", "\r"},
+		{"\t", "\t"},
+		{" \n\r\t", " \n\r\t"},
 	}
 
 	for _, tt := range table {


### PR DESCRIPTION
### What is being done in this PR?
Fixed #74

### What are the main choices made to get to this solution?
Determine if it is a whitespace string with strings.TrimSpace, and if so, return the unmodified input string

### What was discovered while working on it? (Optional)
it panics (but not anymore)

### List the manual test cases you've covered before sending this PR:
Ran `go test -v ./...`, using all the tests supplied in issue #74
