### PR TITLE
Fix pluralization for the word 'lens'

### DIFF
--- a/flect_test.go
+++ b/flect_test.go
@@ -265,6 +265,7 @@ var singlePluralAssertions = []dict{
 	{"horse", "horses", true, true},
 	{"lapse", "lapses", true, true},
 	{"collapse", "collapses", true, true},
+	{"lens", "lenses", true, true},
 	{"truss", "trusses", true, true},
 
 	{"portfolio", "portfolios", true, true}, // -o -os

--- a/plural_rules.go
+++ b/plural_rules.go
@@ -168,6 +168,7 @@ var dictionary = []word{
 	{singular: "buffalo", plural: "buffaloes", alternative: "buffalos"},
 	{singular: "potato", plural: "potatoes"},
 	{singular: "tomato", plural: "tomatoes"},
+	{singular: "lens", plural: "lenses"},
 
 	// uncountables
 	{singular: "equipment", uncountable: true},


### PR DESCRIPTION
### What is being done in this PR?

Fixes #78

Add pluralization rule for the word 'lens'.

### What are the main choices made to get to this solution?

Without this rule, both the `Singularize` and `Pluralize` functions would return incorrect results as described in #78.

### List the manual test cases you've covered before sending this PR:

Ensured the fix is tested via `singlePluralAssertions` in `flect_test.go`.