### PR TITLE
go.mod: remove direct testify reference w/ version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,8 +2,4 @@ module github.com/gobuffalo/flect
 
 go 1.16
 
-exclude github.com/stretchr/testify v1.7.1
-
-require github.com/stretchr/testify v1.8.1
-
 retract [v1.0.0, v1.0.1]


### PR DESCRIPTION
Hi, is it possible to remove the testify versions in the go.mod file? This prevents apps that use flect from specifying their own versions. My preference with `go.mod` is to specify versions in applications and not libraries. 

Here is a comparison of `go mod graph` output:

```sh
github.com/OWNER/APP github.com/gobuffalo/flect@v1.0.3
github.com/gobuffalo/flect@v1.0.3 github.com/stretchr/testify@v1.8.1
go@1.25.5 toolchain@go1.25.5
github.com/stretchr/testify@v1.8.1 github.com/davecgh/go-spew@v1.1.1
github.com/stretchr/testify@v1.8.1 github.com/pmezard/go-difflib@v1.0.0
github.com/stretchr/testify@v1.8.1 github.com/stretchr/objx@v0.5.0
github.com/stretchr/testify@v1.8.1 gopkg.in/yaml.v3@v3.0.1
gopkg.in/yaml.v3@v3.0.1 gopkg.in/check.v1@v0.0.0-20161208181325-20d25e280405
github.com/stretchr/objx@v0.5.0 github.com/stretchr/testify@v1.8.0
github.com/stretchr/testify@v1.8.0 github.com/davecgh/go-spew@v1.1.1
github.com/stretchr/testify@v1.8.0 github.com/pmezard/go-difflib@v1.0.0
github.com/stretchr/testify@v1.8.0 github.com/stretchr/objx@v0.4.0
github.com/stretchr/testify@v1.8.0 gopkg.in/yaml.v3@v3.0.1
github.com/stretchr/objx@v0.4.0 github.com/davecgh/go-spew@v1.1.1
github.com/stretchr/objx@v0.4.0 github.com/stretchr/testify@v1.7.1
github.com/stretchr/testify@v1.7.1 github.com/davecgh/go-spew@v1.1.0
github.com/stretchr/testify@v1.7.1 github.com/pmezard/go-difflib@v1.0.0
github.com/stretchr/testify@v1.7.1 github.com/stretchr/objx@v0.1.0
github.com/stretchr/testify@v1.7.1 gopkg.in/yaml.v3@v3.0.0-20200313102051-9f266ea9e77c
```

Using my fork:

```sh
$ go mod graph
github.com/OWNER/APP github.com/riscdanger/flect@v0.67.0
github.com/OWNER/APP github.com/stretchr/testify@v1.11.1
github.com/OWNER/APP go@1.25.5
github.com/stretchr/testify@v1.11.1 github.com/davecgh/go-spew@v1.1.1
github.com/stretchr/testify@v1.11.1 github.com/pmezard/go-difflib@v1.0.0
github.com/stretchr/testify@v1.11.1 github.com/stretchr/objx@v0.5.2
github.com/stretchr/testify@v1.11.1 gopkg.in/yaml.v3@v3.0.1
go@1.25.5 toolchain@go1.25.5
```