### PR TITLE
Fix lowercase acronym pluralization

### DIFF
--- a/flect_test.go
+++ b/flect_test.go
@@ -333,6 +333,7 @@ var singlePluralAssertions = []dict{
 	{"ID", "IDs", true, true},
 	{"IDS", "IDSes", true, true},
 	// id to ids (ID), ids to idses (IDS) is not supported
+	{"ids", "ids", true, true},
 	{"api", "apis", true, true},
 	{"API", "APIs", true, true},
 	{"html", "htmls", true, true},
@@ -343,6 +344,9 @@ var singlePluralAssertions = []dict{
 	{"SSH", "SSHs", true, true},
 	{"eia", "eias", true, true}, // ia
 	{"EIA", "EIAs", true, true},
+	{"https", "https", true, true},
+	{"HTTPS", "HTTPSes", true, true},
+	{"dns", "dns", true, true},
 	{"DNS", "DNSes", true, true},
 }
 

--- a/pluralize.go
+++ b/pluralize.go
@@ -59,7 +59,8 @@ func (i Ident) Pluralize() Ident {
 	}
 
 	for _, r := range pluralRules {
-		if strings.HasSuffix(s, r.suffix) {
+		// Acronym parts are normalized to uppercase, so only replace an exact suffix.
+		if strings.HasSuffix(s, r.suffix) && strings.HasSuffix(i.Original, s) {
 			return i.ReplaceSuffix(s, r.fn(s))
 		}
 	}

--- a/singularize.go
+++ b/singularize.go
@@ -56,7 +56,8 @@ func (i Ident) Singularize() Ident {
 	}
 
 	for _, r := range singularRules {
-		if strings.HasSuffix(s, r.suffix) {
+		// Acronym parts are normalized to uppercase, so only replace an exact suffix.
+		if strings.HasSuffix(s, r.suffix) && strings.HasSuffix(i.Original, s) {
 			return i.ReplaceSuffix(s, r.fn(s))
 		}
 	}


### PR DESCRIPTION
## What changed

Fixes #71

Known acronyms are normalized to uppercase in `Ident.Parts`. The suffix-rule loops therefore matched the uppercase abbreviation rule for inputs such as `dns`, but `ReplaceSuffix` could not remove the differently-cased suffix from the original string, producing `dnsDNSes`.

Suffix rules now run only when the normalized last part is an exact suffix of the original input. Lowercase `dns`, `ids`, and `https` fall through to the existing already-plural handling, while uppercase `DNS`, `IDS`, and `HTTPS` retain their current `-es` behavior. The same guard is applied to singularization to prevent the analogous duplicated acronym result.

## Tests

- `go test ./... -run '^(Test_Pluralize|Test_PluralizeWithSize|Test_Singularize|Test_SingularizeWithSize)$' -count=1`
- `go test -cover ./... -count=1`
- `go vet ./...`
- `golangci-lint run --new-from-rev=main` (0 issues)
- configured legacy linter equivalents (`govet`, `ineffassign`, `misspell`, `nakedret`, `unconvert`, `staticcheck`) (0 issues)

`go test -race ./...` was attempted, but the local Windows Go toolchain has CGO disabled and no C compiler; the upstream Standard Test workflow will exercise its configured race run.